### PR TITLE
Add metadata export to pokemon-pocket-blog-1.mdx

### DIFF
--- a/content/posts/pokemon-pocket-blog-1.mdx
+++ b/content/posts/pokemon-pocket-blog-1.mdx
@@ -1,3 +1,12 @@
+export const metadata = {
+  title: "blog post 1 example",
+  description: "This is an example blog post 1",
+  publishDate: "2025-07-05",
+  author: "test author",
+  tags: ["strategy", "decklist"],
+  image: ""
+}
+
 # Saturation Point? What’s Next for Pokémon Pocket
 
 ## Maintaining


### PR DESCRIPTION
Added metadata to blog post 1 for SEO and preview support. Includes title, description, publish date, author, and tags.